### PR TITLE
Fixed bounds for the check function

### DIFF
--- a/seven_kyu/consecutive_ducks.js
+++ b/seven_kyu/consecutive_ducks.js
@@ -13,7 +13,7 @@
 
 
 function consecutiveDucks(n) {
-    for (let i = 2; i < (n / 2) + 1; i++) {
+    for (let i = 2; i < n; i++) {
         if(checkMod(i, n)) {
             return true;
         }


### PR DESCRIPTION
When we changed our logic, the bounds of the divisor are different. N can be more than half of the number, because we are no longer summing the digits N, as it now represents the divisor. In other words, N is how many digits are summed to get the target.